### PR TITLE
Update metadata and dependencies to match vanilla template

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,9 +13,20 @@
         "plugin:@typescript-eslint/recommended-requiring-type-checking"
     ],
     "rules": {
+        "eqeqeq": "error",
+        "@typescript-eslint/ban-types": ["error", {
+            "types": {
+                "null": {
+                    "message": "Use `undefined` as the equivalent to Lua's `nil`",
+                    "fixWith": "undefined",
+                    "suggest": ["undefined"]
+                }
+            },
+            "extendDefaults": true
+        }],
+        "no-unused-vars": "off",
         "@typescript-eslint/no-unused-vars": ["error", {"args": "all", "argsIgnorePattern": "^_"}],
         "@typescript-eslint/strict-boolean-expressions": ["error", {"allowString": false, "allowNumber": false}],
-        "@typescript-eslint/restrict-plus-operands": "off",
-        "@typescript-eslint/semi": "error"
+        "@typescript-eslint/restrict-plus-operands": "off"
     }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,32 +1,37 @@
+# Text files
+*.ts text=auto
+*.json text=auto
+*.md text=auto
+
 # Defold Protocol Buffer Text Files (https://github.com/github/linguist/issues/5091)
-*.animationset linguist-language=JSON5
-*.atlas linguist-language=JSON5
-*.camera linguist-language=JSON5
-*.collection linguist-language=JSON5
-*.collectionfactory linguist-language=JSON5
-*.collectionproxy linguist-language=JSON5
-*.collisionobject linguist-language=JSON5
-*.cubemap linguist-language=JSON5
-*.display_profiles linguist-language=JSON5
-*.factory linguist-language=JSON5
-*.font linguist-language=JSON5
-*.gamepads linguist-language=JSON5
-*.go linguist-language=JSON5
-*.gui linguist-language=JSON5
-*.input_binding linguist-language=JSON5
-*.label linguist-language=JSON5
-*.material linguist-language=JSON5
-*.mesh linguist-language=JSON5
-*.model linguist-language=JSON5
-*.particlefx linguist-language=JSON5
-*.render linguist-language=JSON5
-*.sound linguist-language=JSON5
-*.sprite linguist-language=JSON5
-*.spinemodel linguist-language=JSON5
-*.spinescene linguist-language=JSON5
-*.texture_profiles linguist-language=JSON5
-*.tilemap linguist-language=JSON5
-*.tilesource linguist-language=JSON5
+*.animationset linguist-language=Protocol-Buffer-Text-Format
+*.atlas linguist-language=Protocol-Buffer-Text-Format
+*.camera linguist-language=Protocol-Buffer-Text-Format
+*.collection linguist-language=Protocol-Buffer-Text-Format
+*.collectionfactory linguist-language=Protocol-Buffer-Text-Format
+*.collectionproxy linguist-language=Protocol-Buffer-Text-Format
+*.collisionobject linguist-language=Protocol-Buffer-Text-Format
+*.cubemap linguist-language=Protocol-Buffer-Text-Format
+*.display_profiles linguist-language=Protocol-Buffer-Text-Format
+*.factory linguist-language=Protocol-Buffer-Text-Format
+*.font linguist-language=Protocol-Buffer-Text-Format
+*.gamepads linguist-language=Protocol-Buffer-Text-Format
+*.go linguist-language=Protocol-Buffer-Text-Format
+*.gui linguist-language=Protocol-Buffer-Text-Format
+*.input_binding linguist-language=Protocol-Buffer-Text-Format
+*.label linguist-language=Protocol-Buffer-Text-Format
+*.material linguist-language=Protocol-Buffer-Text-Format
+*.mesh linguist-language=Protocol-Buffer-Text-Format
+*.model linguist-language=Protocol-Buffer-Text-Format
+*.particlefx linguist-language=Protocol-Buffer-Text-Format
+*.render linguist-language=Protocol-Buffer-Text-Format
+*.sound linguist-language=Protocol-Buffer-Text-Format
+*.sprite linguist-language=Protocol-Buffer-Text-Format
+*.spinemodel linguist-language=Protocol-Buffer-Text-Format
+*.spinescene linguist-language=Protocol-Buffer-Text-Format
+*.texture_profiles linguist-language=Protocol-Buffer-Text-Format
+*.tilemap linguist-language=Protocol-Buffer-Text-Format
+*.tilesource linguist-language=Protocol-Buffer-Text-Format
 
 # Defold JSON Files
 *.buffer linguist-language=JSON
@@ -43,3 +48,6 @@
 
 # Defold Project Settings
 *.project linguist-language=INI
+
+# Defold Manifest
+*.appmanifest linguist-language=YAML

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,21 +9,21 @@ jobs:
 
     steps:
     - name: Checkout 
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       
     - name: Setup Node
-      uses: actions/setup-node@v2.1.2
+      uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 'lts/*'
       
     - name: Set up JDK
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '17'
 
     - name: Setup Defold
-      uses: dapetcu21/setup-defold@v3.0.2
+      uses: dapetcu21/setup-defold@v3.0.3
       
     - name: Install Dependencies
       run: npm install

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 		"tomblind.local-lua-debugger-vscode",
 		"typescript-to-lua.vscode-typescript-to-lua",
 		"dbaeumer.vscode-eslint",
-		"thejustinwalsh.textproto-grammer"
+		"thejustinwalsh.textproto-grammer",
+		"ts-defold.defold-vscode-build",
 	],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,7 +34,7 @@
         "*.sprite": "textproto",
         "*.texture_profiles": "textproto",
         "*.tilemap": "textproto",
-        "*.tilesource": "textproto"
+        "*.tilesource": "textproto",
     },
     "files.exclude": {
         "node_modules/": true,

--- a/@types/lldebugger-0.0.1.d.ts
+++ b/@types/lldebugger-0.0.1.d.ts
@@ -1,0 +1,7 @@
+/// <library version="0.0.1" src="https://github.com/ts-defold/defold-lldebugger/archive/extension.zip" />
+/** @noSelfInFile **/
+
+/** @noResolution */
+declare module 'lldebugger.debug' {
+  export function start(): void;
+}

--- a/app/main/map.tilemap
+++ b/app/main/map.tilemap
@@ -1,7 +1,7 @@
 tile_set: "/main/map.tilesource"
 layers {
   id: "layer1"
-  z: 0.0
+  z: 0.1
   is_visible: 1
   cell {
     x: 0
@@ -9,6 +9,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -16,6 +17,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -23,6 +25,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -30,6 +33,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -37,6 +41,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -44,6 +49,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -51,6 +57,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -58,6 +65,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -65,6 +73,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -72,6 +81,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -79,6 +89,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -86,6 +97,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -93,6 +105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -100,6 +113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -107,6 +121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -114,6 +129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -121,6 +137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -128,6 +145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -135,6 +153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -142,6 +161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -149,6 +169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -156,6 +177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -163,6 +185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -170,6 +193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -177,6 +201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -184,6 +209,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -191,6 +217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -198,6 +225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -205,6 +233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -212,6 +241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -219,6 +249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -226,6 +257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -233,6 +265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -240,6 +273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -247,6 +281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -254,6 +289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -261,6 +297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -268,6 +305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -275,6 +313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -282,6 +321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -289,6 +329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -296,6 +337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -303,6 +345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -310,6 +353,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -317,6 +361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -324,6 +369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -331,6 +377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -338,6 +385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -345,6 +393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -352,6 +401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -359,6 +409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -366,6 +417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -373,6 +425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -380,6 +433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -387,6 +441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -394,6 +449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -401,6 +457,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -408,6 +465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -415,6 +473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -422,6 +481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -429,6 +489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -436,6 +497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -443,6 +505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -450,6 +513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -457,6 +521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -464,6 +529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -471,6 +537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -478,6 +545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -485,6 +553,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -492,6 +561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -499,6 +569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -506,6 +577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -513,6 +585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -520,6 +593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -527,6 +601,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -534,6 +609,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -541,6 +617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -548,6 +625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -555,6 +633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -562,6 +641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -569,6 +649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -576,6 +657,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -583,6 +665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -590,6 +673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -597,6 +681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -604,6 +689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -611,6 +697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -618,6 +705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -625,6 +713,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -632,6 +721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -639,6 +729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -646,6 +737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -653,6 +745,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -660,6 +753,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -667,6 +761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -674,6 +769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -681,6 +777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -688,6 +785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -695,6 +793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -702,6 +801,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -709,6 +809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -716,6 +817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -723,6 +825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -730,6 +833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -737,6 +841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -744,6 +849,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -751,6 +857,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -758,6 +865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -765,6 +873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -772,6 +881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -779,6 +889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -786,6 +897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -793,6 +905,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -800,6 +913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -807,6 +921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -814,6 +929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -821,6 +937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -828,6 +945,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -835,6 +953,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -842,6 +961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -849,6 +969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -856,6 +977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -863,6 +985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -870,6 +993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -877,6 +1001,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -884,6 +1009,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -891,6 +1017,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -898,6 +1025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -905,6 +1033,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -912,6 +1041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -919,6 +1049,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -926,6 +1057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -933,6 +1065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -940,6 +1073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -947,6 +1081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -954,6 +1089,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -961,6 +1097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -968,6 +1105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -975,6 +1113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -982,6 +1121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -989,6 +1129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -996,6 +1137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -1003,6 +1145,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -1010,6 +1153,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -1017,6 +1161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -1024,6 +1169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -1031,6 +1177,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -1038,6 +1185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -1045,6 +1193,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -1052,6 +1201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -1059,6 +1209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -1066,6 +1217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -1073,6 +1225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -1080,6 +1233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -1087,6 +1241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -1094,6 +1249,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -1101,6 +1257,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -1108,6 +1265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -1115,6 +1273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -1122,6 +1281,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -1129,6 +1289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -1136,6 +1297,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -1143,6 +1305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -1150,6 +1313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -1157,6 +1321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -1164,6 +1329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -1171,6 +1337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -1178,6 +1345,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -1185,6 +1353,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -1192,6 +1361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -1199,6 +1369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -1206,6 +1377,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -1213,6 +1385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -1220,6 +1393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -1227,6 +1401,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -1234,6 +1409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -1241,6 +1417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -1248,6 +1425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -1255,6 +1433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -1262,6 +1441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -1269,6 +1449,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -1276,6 +1457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -1283,6 +1465,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -1290,6 +1473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -1297,6 +1481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -1304,6 +1489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -1311,6 +1497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -1318,6 +1505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -1325,6 +1513,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -1332,6 +1521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -1339,6 +1529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -1346,6 +1537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -1353,6 +1545,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -1360,6 +1553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -1367,6 +1561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -1374,6 +1569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -1381,6 +1577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -1388,6 +1585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -1395,6 +1593,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -1402,6 +1601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -1409,6 +1609,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -1416,6 +1617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -1423,6 +1625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -1430,6 +1633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -1437,6 +1641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -1444,6 +1649,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -1451,6 +1657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -1458,6 +1665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -1465,6 +1673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -1472,6 +1681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -1479,6 +1689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -1486,6 +1697,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -1493,6 +1705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -1500,6 +1713,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -1507,6 +1721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -1514,6 +1729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -1521,6 +1737,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -1528,6 +1745,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -1535,6 +1753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -1542,6 +1761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -1549,6 +1769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -1556,6 +1777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -1563,6 +1785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -1570,6 +1793,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -1577,6 +1801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -1584,6 +1809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -1591,6 +1817,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -1598,6 +1825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -1605,6 +1833,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -1612,6 +1841,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -1619,6 +1849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -1626,6 +1857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -1633,6 +1865,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -1640,6 +1873,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -1647,6 +1881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -1654,6 +1889,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -1661,6 +1897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -1668,6 +1905,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -1675,6 +1913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -1682,6 +1921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -1689,6 +1929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -1696,6 +1937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -1703,6 +1945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -1710,6 +1953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -1717,6 +1961,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -1724,6 +1969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -1731,6 +1977,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -1738,6 +1985,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -1745,6 +1993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -1752,6 +2001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -1759,6 +2009,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -1766,6 +2017,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -1773,6 +2025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -1780,6 +2033,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -1787,6 +2041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -1794,6 +2049,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -1801,6 +2057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -1808,6 +2065,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -1815,6 +2073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -1822,6 +2081,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -1829,6 +2089,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -1836,6 +2097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -1843,6 +2105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -1850,6 +2113,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -1857,6 +2121,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -1864,6 +2129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -1871,6 +2137,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -1878,6 +2145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -1885,6 +2153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -1892,6 +2161,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -1899,6 +2169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -1906,6 +2177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -1913,6 +2185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -1920,6 +2193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -1927,6 +2201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -1934,6 +2209,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -1941,6 +2217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -1948,6 +2225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -1955,6 +2233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -1962,6 +2241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -1969,6 +2249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -1976,6 +2257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -1983,6 +2265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -1990,6 +2273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -1997,6 +2281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -2004,6 +2289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -2011,6 +2297,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -2018,6 +2305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -2025,6 +2313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -2032,6 +2321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -2039,6 +2329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -2046,6 +2337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -2053,6 +2345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -2060,6 +2353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -2067,6 +2361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -2074,6 +2369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -2081,6 +2377,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -2088,6 +2385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -2095,6 +2393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -2102,6 +2401,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -2109,6 +2409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -2116,6 +2417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -2123,6 +2425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -2130,6 +2433,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -2137,6 +2441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -2144,6 +2449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -2151,6 +2457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -2158,6 +2465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -2165,6 +2473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -2172,6 +2481,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -2179,6 +2489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -2186,6 +2497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -2193,6 +2505,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -2200,6 +2513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -2207,6 +2521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -2214,6 +2529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -2221,6 +2537,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -2228,6 +2545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -2235,6 +2553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -2242,6 +2561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -2249,6 +2569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -2256,6 +2577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -2263,6 +2585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -2270,6 +2593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -2277,6 +2601,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -2284,6 +2609,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -2291,6 +2617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -2298,6 +2625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -2305,6 +2633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -2312,6 +2641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -2319,6 +2649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -2326,6 +2657,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -2333,6 +2665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -2340,6 +2673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -2347,6 +2681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -2354,6 +2689,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -2361,6 +2697,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -2368,6 +2705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -2375,6 +2713,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -2382,6 +2721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -2389,6 +2729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -2396,6 +2737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -2403,6 +2745,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -2410,6 +2753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -2417,6 +2761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -2424,6 +2769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -2431,6 +2777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -2438,6 +2785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -2445,6 +2793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -2452,6 +2801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -2459,6 +2809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -2466,6 +2817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -2473,6 +2825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -2480,6 +2833,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -2487,6 +2841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -2494,6 +2849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -2501,6 +2857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -2508,6 +2865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -2515,6 +2873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -2522,6 +2881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -2529,6 +2889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -2536,6 +2897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -2543,6 +2905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -2550,6 +2913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -2557,6 +2921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -2564,6 +2929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -2571,6 +2937,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -2578,6 +2945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -2585,6 +2953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -2592,6 +2961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -2599,6 +2969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -2606,6 +2977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -2613,6 +2985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -2620,6 +2993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -2627,6 +3001,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -2634,6 +3009,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -2641,6 +3017,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -2648,6 +3025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -2655,6 +3033,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -2662,6 +3041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -2669,6 +3049,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -2676,6 +3057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -2683,6 +3065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -2690,6 +3073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -2697,6 +3081,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -2704,6 +3089,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -2711,6 +3097,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -2718,6 +3105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -2725,6 +3113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -2732,6 +3121,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -2739,6 +3129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -2746,6 +3137,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -2753,6 +3145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -2760,6 +3153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -2767,6 +3161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -2774,6 +3169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -2781,6 +3177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -2788,6 +3185,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -2795,6 +3193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -2802,6 +3201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -2809,6 +3209,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -2816,6 +3217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -2823,6 +3225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -2830,6 +3233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -2837,6 +3241,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -2844,6 +3249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -2851,6 +3257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -2858,6 +3265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -2865,6 +3273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -2872,6 +3281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -2879,6 +3289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -2886,6 +3297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -2893,6 +3305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -2900,6 +3313,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -2907,6 +3321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -2914,6 +3329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -2921,6 +3337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -2928,6 +3345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -2935,6 +3353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -2942,6 +3361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -2949,6 +3369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -2956,6 +3377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -2963,6 +3385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -2970,6 +3393,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -2977,6 +3401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -2984,6 +3409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -2991,6 +3417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -2998,6 +3425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -3005,6 +3433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -3012,6 +3441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -3019,6 +3449,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -3026,6 +3457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -3033,6 +3465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -3040,6 +3473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -3047,6 +3481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -3054,6 +3489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -3061,6 +3497,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -3068,6 +3505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -3075,6 +3513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -3082,6 +3521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -3089,6 +3529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -3096,6 +3537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -3103,6 +3545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -3110,6 +3553,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -3117,6 +3561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -3124,6 +3569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -3131,6 +3577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -3138,6 +3585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -3145,6 +3593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -3152,6 +3601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -3159,6 +3609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -3166,6 +3617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -3173,6 +3625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -3180,6 +3633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -3187,6 +3641,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -3194,6 +3649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -3201,6 +3657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -3208,6 +3665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -3215,6 +3673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -3222,6 +3681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -3229,6 +3689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -3236,6 +3697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -3243,6 +3705,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -3250,6 +3713,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -3257,6 +3721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -3264,6 +3729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -3271,6 +3737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -3278,6 +3745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -3285,6 +3753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -3292,6 +3761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -3299,6 +3769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -3306,6 +3777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -3313,6 +3785,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -3320,6 +3793,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -3327,6 +3801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -3334,6 +3809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -3341,6 +3817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -3348,6 +3825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -3355,6 +3833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -3362,6 +3841,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -3369,6 +3849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -3376,6 +3857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -3383,6 +3865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -3390,6 +3873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -3397,6 +3881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -3404,6 +3889,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -3411,6 +3897,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -3418,6 +3905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -3425,6 +3913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -3432,6 +3921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -3439,6 +3929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -3446,6 +3937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -3453,6 +3945,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -3460,6 +3953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -3467,6 +3961,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -3474,6 +3969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -3481,6 +3977,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -3488,6 +3985,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -3495,6 +3993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -3502,6 +4001,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -3509,6 +4009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -3516,6 +4017,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -3523,6 +4025,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -3530,6 +4033,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -3537,6 +4041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -3544,6 +4049,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -3551,6 +4057,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -3558,6 +4065,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -3565,6 +4073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -3572,6 +4081,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -3579,6 +4089,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -3586,6 +4097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -3593,6 +4105,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -3600,6 +4113,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -3607,6 +4121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -3614,6 +4129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -3621,6 +4137,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -3628,6 +4145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -3635,6 +4153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -3642,6 +4161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -3649,6 +4169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -3656,6 +4177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -3663,6 +4185,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -3670,6 +4193,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -3677,6 +4201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -3684,6 +4209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -3691,6 +4217,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -3698,6 +4225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -3705,6 +4233,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -3712,6 +4241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -3719,6 +4249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -3726,6 +4257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -3733,6 +4265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -3740,6 +4273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -3747,6 +4281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -3754,6 +4289,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -3761,6 +4297,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -3768,6 +4305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -3775,6 +4313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -3782,6 +4321,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -3789,6 +4329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -3796,6 +4337,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -3803,6 +4345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -3810,6 +4353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -3817,6 +4361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -3824,6 +4369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -3831,6 +4377,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -3838,6 +4385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -3845,6 +4393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -3852,6 +4401,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -3859,6 +4409,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -3866,6 +4417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -3873,6 +4425,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -3880,6 +4433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -3887,6 +4441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -3894,6 +4449,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -3901,6 +4457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -3908,6 +4465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -3915,6 +4473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -3922,6 +4481,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -3929,6 +4489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -3936,6 +4497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -3943,6 +4505,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -3950,6 +4513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -3957,6 +4521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -3964,6 +4529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -3971,6 +4537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -3978,6 +4545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -3985,6 +4553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -3992,6 +4561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -3999,6 +4569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -4006,6 +4577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -4013,6 +4585,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -4020,6 +4593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -4027,6 +4601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -4034,6 +4609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -4041,6 +4617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -4048,6 +4625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -4055,6 +4633,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -4062,6 +4641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -4069,6 +4649,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -4076,6 +4657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -4083,6 +4665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -4090,6 +4673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -4097,6 +4681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -4104,6 +4689,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -4111,6 +4697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -4118,6 +4705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -4125,6 +4713,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -4132,6 +4721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -4139,6 +4729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -4146,6 +4737,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -4153,6 +4745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -4160,6 +4753,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -4167,6 +4761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -4174,6 +4769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -4181,6 +4777,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -4188,6 +4785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -4195,6 +4793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -4202,6 +4801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -4209,6 +4809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -4216,6 +4817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -4223,6 +4825,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -4230,6 +4833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -4237,6 +4841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -4244,6 +4849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -4251,6 +4857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -4258,6 +4865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -4265,6 +4873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -4272,6 +4881,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -4279,6 +4889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -4286,6 +4897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -4293,6 +4905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -4300,6 +4913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -4307,6 +4921,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -4314,6 +4929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -4321,6 +4937,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -4328,6 +4945,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -4335,6 +4953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -4342,6 +4961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -4349,6 +4969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -4356,6 +4977,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -4363,6 +4985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -4370,6 +4993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -4377,6 +5001,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -4384,6 +5009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -4391,6 +5017,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -4398,6 +5025,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -4405,6 +5033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -4412,6 +5041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -4419,6 +5049,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -4426,6 +5057,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -4433,6 +5065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -4440,6 +5073,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -4447,6 +5081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -4454,6 +5089,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -4461,6 +5097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -4468,6 +5105,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -4475,6 +5113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -4482,6 +5121,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -4489,6 +5129,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -4496,6 +5137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -4503,6 +5145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -4510,6 +5153,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -4517,6 +5161,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -4524,6 +5169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -4531,6 +5177,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -4538,6 +5185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -4545,6 +5193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -4552,6 +5201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -4559,6 +5209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -4566,6 +5217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -4573,6 +5225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -4580,6 +5233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -4587,6 +5241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -4594,6 +5249,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -4601,6 +5257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -4608,6 +5265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -4615,6 +5273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -4622,6 +5281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -4629,6 +5289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -4636,6 +5297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -4643,6 +5305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -4650,6 +5313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -4657,6 +5321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -4664,6 +5329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -4671,6 +5337,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -4678,6 +5345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -4685,6 +5353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -4692,6 +5361,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -4699,6 +5369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -4706,6 +5377,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -4713,6 +5385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -4720,6 +5393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -4727,6 +5401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -4734,6 +5409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -4741,6 +5417,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -4748,6 +5425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -4755,6 +5433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -4762,6 +5441,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -4769,6 +5449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -4776,6 +5457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -4783,6 +5465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -4790,6 +5473,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -4797,6 +5481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -4804,6 +5489,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -4811,6 +5497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -4818,6 +5505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -4825,6 +5513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -4832,6 +5521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -4839,6 +5529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -4846,6 +5537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -4853,6 +5545,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -4860,6 +5553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -4867,6 +5561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -4874,6 +5569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -4881,6 +5577,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -4888,6 +5585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -4895,6 +5593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -4902,6 +5601,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -4909,6 +5609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -4916,6 +5617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -4923,6 +5625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -4930,6 +5633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -4937,6 +5641,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -4944,6 +5649,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -4951,6 +5657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -4958,6 +5665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -4965,6 +5673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -4972,6 +5681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -4979,6 +5689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -4986,6 +5697,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -4993,6 +5705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -5000,6 +5713,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -5007,6 +5721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -5014,6 +5729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -5021,6 +5737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -5028,6 +5745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -5035,6 +5753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -5042,6 +5761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -5049,6 +5769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -5056,6 +5777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -5063,6 +5785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -5070,6 +5793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -5077,6 +5801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -5084,6 +5809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -5091,6 +5817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -5098,6 +5825,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -5105,6 +5833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -5112,6 +5841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -5119,6 +5849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -5126,6 +5857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -5133,6 +5865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -5140,6 +5873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -5147,6 +5881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -5154,6 +5889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -5161,6 +5897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -5168,6 +5905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -5175,6 +5913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -5182,6 +5921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -5189,6 +5929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -5196,6 +5937,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -5203,6 +5945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -5210,6 +5953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -5217,6 +5961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -5224,6 +5969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -5231,6 +5977,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -5238,6 +5985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -5245,6 +5993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -5252,6 +6001,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -5259,6 +6009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -5266,6 +6017,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -5273,6 +6025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -5280,6 +6033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -5287,6 +6041,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -5294,6 +6049,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -5301,6 +6057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -5308,6 +6065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -5315,6 +6073,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -5322,6 +6081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -5329,6 +6089,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -5336,6 +6097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -5343,6 +6105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -5350,6 +6113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -5357,6 +6121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -5364,6 +6129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -5371,6 +6137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -5378,6 +6145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -5385,6 +6153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -5392,6 +6161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -5399,6 +6169,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -5406,6 +6177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -5413,6 +6185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -5420,6 +6193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -5427,6 +6201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -5434,6 +6209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -5441,6 +6217,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -5448,6 +6225,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -5455,6 +6233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -5462,6 +6241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -5469,6 +6249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -5476,6 +6257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -5483,6 +6265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -5490,6 +6273,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -5497,6 +6281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -5504,6 +6289,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -5511,6 +6297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -5518,6 +6305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -5525,6 +6313,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -5532,6 +6321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -5539,6 +6329,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -5546,6 +6337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -5553,6 +6345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -5560,6 +6353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -5567,6 +6361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -5574,6 +6369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -5581,6 +6377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -5588,6 +6385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -5595,6 +6393,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -5602,6 +6401,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -5609,6 +6409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -5616,6 +6417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -5623,6 +6425,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -5630,6 +6433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -5637,6 +6441,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -5644,6 +6449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -5651,6 +6457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -5658,6 +6465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -5665,6 +6473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -5672,6 +6481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -5679,6 +6489,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -5686,6 +6497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -5693,6 +6505,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -5700,6 +6513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -5707,6 +6521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -5714,6 +6529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -5721,6 +6537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -5728,6 +6545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -5735,6 +6553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -5742,6 +6561,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -5749,6 +6569,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -5756,6 +6577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -5763,6 +6585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -5770,6 +6593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -5777,6 +6601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -5784,6 +6609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -5791,6 +6617,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -5798,6 +6625,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -5805,6 +6633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -5812,6 +6641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -5819,6 +6649,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -5826,6 +6657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -5833,6 +6665,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -5840,6 +6673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -5847,6 +6681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -5854,6 +6689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -5861,6 +6697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -5868,6 +6705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -5875,6 +6713,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -5882,6 +6721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -5889,6 +6729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -5896,6 +6737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -5903,6 +6745,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -5910,6 +6753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -5917,6 +6761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -5924,6 +6769,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -5931,6 +6777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -5938,6 +6785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -5945,6 +6793,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -5952,6 +6801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -5959,6 +6809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -5966,6 +6817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -5973,6 +6825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -5980,6 +6833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -5987,6 +6841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -5994,6 +6849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -6001,6 +6857,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -6008,6 +6865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -6015,6 +6873,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -6022,6 +6881,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -6029,6 +6889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -6036,6 +6897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -6043,6 +6905,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -6050,6 +6913,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -6057,6 +6921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -6064,6 +6929,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -6071,6 +6937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -6078,6 +6945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -6085,6 +6953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -6092,6 +6961,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -6099,6 +6969,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -6106,6 +6977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -6113,6 +6985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -6120,6 +6993,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -6127,6 +7001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -6134,6 +7009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -6141,6 +7017,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -6148,6 +7025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -6155,6 +7033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -6162,6 +7041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -6169,6 +7049,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -6176,6 +7057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -6183,6 +7065,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -6190,6 +7073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -6197,6 +7081,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -6204,6 +7089,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -6211,6 +7097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -6218,6 +7105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -6225,6 +7113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -6232,6 +7121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -6239,6 +7129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -6246,6 +7137,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -6253,6 +7145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -6260,6 +7153,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -6267,6 +7161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -6274,6 +7169,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -6281,6 +7177,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -6288,6 +7185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -6295,6 +7193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -6302,6 +7201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -6309,6 +7209,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -6316,6 +7217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -6323,6 +7225,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -6330,6 +7233,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -6337,6 +7241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -6344,6 +7249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -6351,6 +7257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -6358,6 +7265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -6365,6 +7273,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -6372,6 +7281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -6379,6 +7289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -6386,6 +7297,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -6393,6 +7305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -6400,6 +7313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -6407,6 +7321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -6414,6 +7329,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -6421,6 +7337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -6428,6 +7345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -6435,6 +7353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -6442,6 +7361,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -6449,6 +7369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -6456,6 +7377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -6463,6 +7385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -6470,6 +7393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -6477,6 +7401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -6484,6 +7409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -6491,6 +7417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -6498,6 +7425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -6505,6 +7433,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -6512,6 +7441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -6519,6 +7449,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -6526,6 +7457,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -6533,6 +7465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -6540,6 +7473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -6547,6 +7481,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -6554,6 +7489,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -6561,6 +7497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -6568,6 +7505,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -6575,6 +7513,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -6582,6 +7521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -6589,6 +7529,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -6596,6 +7537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -6603,6 +7545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -6610,6 +7553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -6617,6 +7561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -6624,6 +7569,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -6631,6 +7577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -6638,6 +7585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -6645,6 +7593,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -6652,6 +7601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -6659,6 +7609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -6666,6 +7617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -6673,6 +7625,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -6680,6 +7633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -6687,6 +7641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -6694,6 +7649,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -6701,6 +7657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -6708,6 +7665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -6715,6 +7673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -6722,6 +7681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -6729,6 +7689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -6736,6 +7697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -6743,6 +7705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -6750,6 +7713,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -6757,6 +7721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -6764,6 +7729,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -6771,6 +7737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -6778,6 +7745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -6785,6 +7753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -6792,6 +7761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -6799,6 +7769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -6806,6 +7777,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -6813,6 +7785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -6820,6 +7793,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -6827,6 +7801,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -6834,6 +7809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -6841,6 +7817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -6848,6 +7825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -6855,6 +7833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -6862,6 +7841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -6869,6 +7849,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -6876,6 +7857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -6883,6 +7865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -6890,6 +7873,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -6897,6 +7881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -6904,6 +7889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -6911,6 +7897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -6918,6 +7905,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -6925,6 +7913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -6932,6 +7921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -6939,6 +7929,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -6946,6 +7937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -6953,6 +7945,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -6960,6 +7953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -6967,6 +7961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -6974,6 +7969,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -6981,6 +7977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -6988,6 +7985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -6995,6 +7993,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -7002,6 +8001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -7009,6 +8009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -7016,6 +8017,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -7023,6 +8025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -7030,6 +8033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -7037,6 +8041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -7044,6 +8049,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -7051,6 +8057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -7058,6 +8065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -7065,6 +8073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -7072,6 +8081,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -7079,6 +8089,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -7086,6 +8097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -7093,6 +8105,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -7100,6 +8113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -7107,6 +8121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -7114,6 +8129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -7121,6 +8137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -7128,6 +8145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -7135,6 +8153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -7142,6 +8161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -7149,6 +8169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -7156,6 +8177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -7163,6 +8185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -7170,6 +8193,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -7177,6 +8201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -7184,6 +8209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -7191,6 +8217,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -7198,6 +8225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -7205,6 +8233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -7212,6 +8241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -7219,6 +8249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -7226,6 +8257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -7233,6 +8265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -7240,6 +8273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -7247,6 +8281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -7254,6 +8289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -7261,6 +8297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -7268,6 +8305,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -7275,6 +8313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -7282,6 +8321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -7289,6 +8329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -7296,6 +8337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -7303,6 +8345,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -7310,6 +8353,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -7317,6 +8361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -7324,6 +8369,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -7331,6 +8377,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -7338,6 +8385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -7345,6 +8393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -7352,6 +8401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -7359,6 +8409,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -7366,6 +8417,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -7373,6 +8425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -7380,6 +8433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -7387,6 +8441,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -7394,6 +8449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -7401,6 +8457,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -7408,6 +8465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -7415,6 +8473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -7422,6 +8481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -7429,6 +8489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -7436,6 +8497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -7443,6 +8505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -7450,6 +8513,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -7457,6 +8521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -7464,6 +8529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -7471,6 +8537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -7478,6 +8545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -7485,6 +8553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -7492,6 +8561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -7499,6 +8569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -7506,6 +8577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -7513,6 +8585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -7520,6 +8593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -7527,6 +8601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -7534,6 +8609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -7541,6 +8617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -7548,6 +8625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -7555,6 +8633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -7562,6 +8641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -7569,6 +8649,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -7576,6 +8657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -7583,6 +8665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -7590,6 +8673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -7597,6 +8681,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -7604,6 +8689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -7611,6 +8697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -7618,6 +8705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -7625,6 +8713,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -7632,6 +8721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -7639,6 +8729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -7646,6 +8737,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -7653,6 +8745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -7660,6 +8753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -7667,6 +8761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -7674,6 +8769,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -7681,6 +8777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -7688,6 +8785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -7695,6 +8793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -7702,6 +8801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -7709,6 +8809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -7716,6 +8817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -7723,6 +8825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -7730,6 +8833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -7737,6 +8841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -7744,6 +8849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -7751,6 +8857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -7758,6 +8865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -7765,6 +8873,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -7772,6 +8881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -7779,6 +8889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -7786,6 +8897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -7793,6 +8905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -7800,6 +8913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -7807,6 +8921,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -7814,6 +8929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -7821,6 +8937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -7828,6 +8945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -7835,6 +8953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -7842,6 +8961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -7849,6 +8969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -7856,6 +8977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -7863,6 +8985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -7870,6 +8993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -7877,6 +9001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -7884,6 +9009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -7891,6 +9017,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -7898,6 +9025,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -7905,6 +9033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -7912,6 +9041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -7919,6 +9049,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -7926,6 +9057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -7933,6 +9065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -7940,6 +9073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -7947,6 +9081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -7954,6 +9089,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -7961,6 +9097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -7968,6 +9105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -7975,6 +9113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -7982,6 +9121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -7989,6 +9129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -7996,6 +9137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -8003,6 +9145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -8010,6 +9153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -8017,6 +9161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -8024,6 +9169,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -8031,6 +9177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -8038,6 +9185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -8045,6 +9193,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -8052,6 +9201,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -8059,6 +9209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -8066,6 +9217,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -8073,6 +9225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -8080,6 +9233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -8087,6 +9241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -8094,6 +9249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -8101,6 +9257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -8108,6 +9265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -8115,6 +9273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -8122,6 +9281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -8129,6 +9289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -8136,6 +9297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -8143,6 +9305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -8150,6 +9313,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -8157,6 +9321,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -8164,6 +9329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -8171,6 +9337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -8178,6 +9345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -8185,6 +9353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -8192,6 +9361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -8199,6 +9369,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -8206,6 +9377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -8213,6 +9385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -8220,6 +9393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -8227,6 +9401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -8234,6 +9409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -8241,6 +9417,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -8248,6 +9425,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -8255,6 +9433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -8262,6 +9441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -8269,6 +9449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -8276,6 +9457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -8283,6 +9465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -8290,6 +9473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -8297,6 +9481,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -8304,6 +9489,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -8311,6 +9497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -8318,6 +9505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -8325,6 +9513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -8332,6 +9521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -8339,6 +9529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -8346,6 +9537,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -8353,6 +9545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -8360,6 +9553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -8367,6 +9561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -8374,6 +9569,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -8381,6 +9577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -8388,6 +9585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -8395,6 +9593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -8402,6 +9601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -8409,6 +9609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -8416,6 +9617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -8423,6 +9625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -8430,6 +9633,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -8437,6 +9641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -8444,6 +9649,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -8451,6 +9657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -8458,6 +9665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -8465,6 +9673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -8472,6 +9681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -8479,6 +9689,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -8486,6 +9697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -8493,6 +9705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -8500,6 +9713,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -8507,6 +9721,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -8514,6 +9729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -8521,6 +9737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -8528,6 +9745,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -8535,6 +9753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -8542,6 +9761,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -8549,6 +9769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -8556,6 +9777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -8563,6 +9785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -8570,6 +9793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -8577,6 +9801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -8584,6 +9809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -8591,6 +9817,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -8598,6 +9825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -8605,6 +9833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -8612,6 +9841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -8619,6 +9849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -8626,6 +9857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -8633,6 +9865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -8640,6 +9873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -8647,6 +9881,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -8654,6 +9889,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -8661,6 +9897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -8668,6 +9905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -8675,6 +9913,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -8682,6 +9921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -8689,6 +9929,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -8696,6 +9937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -8703,6 +9945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -8710,6 +9953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -8717,6 +9961,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -8724,6 +9969,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -8731,6 +9977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -8738,6 +9985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -8745,6 +9993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -8752,6 +10001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -8759,6 +10009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -8766,6 +10017,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -8773,6 +10025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -8780,6 +10033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -8787,6 +10041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -8794,6 +10049,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -8801,6 +10057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -8808,6 +10065,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -8815,6 +10073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -8822,6 +10081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -8829,6 +10089,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -8836,6 +10097,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -8843,6 +10105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -8850,6 +10113,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -8857,6 +10121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -8864,6 +10129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -8871,6 +10137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -8878,6 +10145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -8885,6 +10153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -8892,6 +10161,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -8899,6 +10169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -8906,6 +10177,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -8913,6 +10185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -8920,6 +10193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -8927,6 +10201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -8934,6 +10209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -8941,6 +10217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -8948,6 +10225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -8955,6 +10233,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -8962,6 +10241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -8969,6 +10249,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -8976,6 +10257,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -8983,6 +10265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -8990,6 +10273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -8997,6 +10281,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -9004,6 +10289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -9011,6 +10297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -9018,6 +10305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -9025,6 +10313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -9032,6 +10321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -9039,6 +10329,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -9046,6 +10337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -9053,6 +10345,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -9060,6 +10353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -9067,6 +10361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -9074,6 +10369,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -9081,6 +10377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -9088,6 +10385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -9095,6 +10393,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -9102,6 +10401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -9109,6 +10409,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -9116,6 +10417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -9123,6 +10425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -9130,6 +10433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -9137,6 +10441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -9144,6 +10449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -9151,6 +10457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -9158,6 +10465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -9165,6 +10473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -9172,6 +10481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -9179,6 +10489,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -9186,6 +10497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -9193,6 +10505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -9200,6 +10513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -9207,6 +10521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -9214,6 +10529,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -9221,6 +10537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -9228,6 +10545,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -9235,6 +10553,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -9242,6 +10561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -9249,6 +10569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -9256,6 +10577,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -9263,6 +10585,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -9270,6 +10593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -9277,6 +10601,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -9284,6 +10609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -9291,6 +10617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -9298,6 +10625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -9305,6 +10633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -9312,6 +10641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -9319,6 +10649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -9326,6 +10657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -9333,6 +10665,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -9340,6 +10673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -9347,6 +10681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -9354,6 +10689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -9361,6 +10697,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -9368,6 +10705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -9375,6 +10713,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -9382,6 +10721,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -9389,6 +10729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -9396,6 +10737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -9403,6 +10745,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -9410,6 +10753,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -9417,6 +10761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -9424,6 +10769,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -9431,6 +10777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -9438,6 +10785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -9445,6 +10793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -9452,6 +10801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -9459,6 +10809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -9466,6 +10817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -9473,6 +10825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -9480,6 +10833,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -9487,6 +10841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -9494,6 +10849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -9501,6 +10857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -9508,6 +10865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -9515,6 +10873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -9522,6 +10881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -9529,6 +10889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -9536,6 +10897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -9543,6 +10905,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -9550,6 +10913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -9557,6 +10921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -9564,6 +10929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -9571,6 +10937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -9578,6 +10945,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -9585,6 +10953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -9592,6 +10961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -9599,6 +10969,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -9606,6 +10977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -9613,6 +10985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -9620,6 +10993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -9627,6 +11001,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -9634,6 +11009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -9641,6 +11017,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -9648,6 +11025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -9655,6 +11033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -9662,6 +11041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -9669,6 +11049,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -9676,6 +11057,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -9683,6 +11065,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -9690,6 +11073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -9697,6 +11081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -9704,6 +11089,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -9711,6 +11097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -9718,6 +11105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -9725,6 +11113,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -9732,6 +11121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -9739,6 +11129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -9746,6 +11137,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -9753,6 +11145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -9760,6 +11153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -9767,6 +11161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -9774,6 +11169,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -9781,6 +11177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -9788,6 +11185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -9795,6 +11193,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -9802,6 +11201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -9809,6 +11209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -9816,6 +11217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -9823,6 +11225,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -9830,6 +11233,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -9837,6 +11241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -9844,6 +11249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -9851,6 +11257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -9858,6 +11265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -9865,6 +11273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -9872,6 +11281,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -9879,6 +11289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -9886,6 +11297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -9893,6 +11305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -9900,6 +11313,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -9907,6 +11321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -9914,6 +11329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -9921,6 +11337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -9928,6 +11345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -9935,6 +11353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -9942,6 +11361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -9949,6 +11369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -9956,6 +11377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -9963,6 +11385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -9970,6 +11393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -9977,6 +11401,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -9984,6 +11409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -9991,6 +11417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -9998,6 +11425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -10005,6 +11433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -10012,6 +11441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -10019,6 +11449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -10026,6 +11457,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -10033,6 +11465,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -10040,6 +11473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -10047,6 +11481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -10054,6 +11489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -10061,6 +11497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -10068,6 +11505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -10075,6 +11513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -10082,6 +11521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -10089,6 +11529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -10096,6 +11537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -10103,6 +11545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -10110,6 +11553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -10117,6 +11561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -10124,6 +11569,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -10131,6 +11577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -10138,6 +11585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -10145,6 +11593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -10152,6 +11601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -10159,6 +11609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -10166,6 +11617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -10173,6 +11625,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -10180,6 +11633,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -10187,6 +11641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -10194,6 +11649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -10201,6 +11657,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -10208,6 +11665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -10215,6 +11673,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -10222,6 +11681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -10229,6 +11689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -10236,6 +11697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -10243,6 +11705,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -10250,6 +11713,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -10257,6 +11721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -10264,6 +11729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -10271,6 +11737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -10278,6 +11745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -10285,6 +11753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -10292,6 +11761,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -10299,6 +11769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -10306,6 +11777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -10313,6 +11785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -10320,6 +11793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -10327,6 +11801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -10334,6 +11809,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -10341,6 +11817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -10348,6 +11825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -10355,6 +11833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -10362,6 +11841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -10369,6 +11849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -10376,6 +11857,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -10383,6 +11865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -10390,6 +11873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -10397,6 +11881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -10404,6 +11889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -10411,6 +11897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -10418,6 +11905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -10425,6 +11913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -10432,6 +11921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -10439,6 +11929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -10446,6 +11937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -10453,6 +11945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -10460,6 +11953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -10467,6 +11961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -10474,6 +11969,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -10481,6 +11977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -10488,6 +11985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -10495,6 +11993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -10502,6 +12001,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -10509,6 +12009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -10516,6 +12017,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -10523,6 +12025,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -10530,6 +12033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -10537,6 +12041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -10544,6 +12049,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -10551,6 +12057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -10558,6 +12065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -10565,6 +12073,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -10572,6 +12081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -10579,6 +12089,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -10586,6 +12097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -10593,6 +12105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -10600,6 +12113,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -10607,6 +12121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -10614,6 +12129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -10621,6 +12137,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -10628,6 +12145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -10635,6 +12153,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -10642,6 +12161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -10649,6 +12169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -10656,6 +12177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -10663,6 +12185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -10670,6 +12193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -10677,6 +12201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -10684,6 +12209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -10691,6 +12217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -10698,6 +12225,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -10705,6 +12233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -10712,6 +12241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -10719,6 +12249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -10726,6 +12257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -10733,6 +12265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -10740,6 +12273,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -10747,6 +12281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -10754,6 +12289,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -10761,6 +12297,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -10768,6 +12305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -10775,6 +12313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -10782,6 +12321,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -10789,6 +12329,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -10796,6 +12337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -10803,6 +12345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -10810,6 +12353,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -10817,6 +12361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -10824,6 +12369,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -10831,6 +12377,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -10838,6 +12385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -10845,6 +12393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -10852,6 +12401,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -10859,6 +12409,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -10866,6 +12417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -10873,6 +12425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -10880,6 +12433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -10887,6 +12441,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -10894,6 +12449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -10901,6 +12457,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -10908,6 +12465,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -10915,6 +12473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -10922,6 +12481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -10929,6 +12489,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -10936,6 +12497,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -10943,6 +12505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -10950,6 +12513,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -10957,6 +12521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -10964,6 +12529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -10971,6 +12537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -10978,6 +12545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -10985,6 +12553,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -10992,6 +12561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -10999,6 +12569,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -11006,6 +12577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -11013,6 +12585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -11020,6 +12593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -11027,6 +12601,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -11034,6 +12609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -11041,6 +12617,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -11048,6 +12625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -11055,6 +12633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -11062,6 +12641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -11069,6 +12649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -11076,6 +12657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -11083,6 +12665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -11090,6 +12673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -11097,6 +12681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -11104,6 +12689,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -11111,6 +12697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -11118,6 +12705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -11125,6 +12713,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -11132,6 +12721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -11139,6 +12729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -11146,6 +12737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -11153,6 +12745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -11160,6 +12753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -11167,6 +12761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -11174,6 +12769,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -11181,6 +12777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -11188,6 +12785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -11195,6 +12793,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -11202,6 +12801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -11209,6 +12809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -11216,6 +12817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -11223,6 +12825,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -11230,6 +12833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -11237,6 +12841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -11244,6 +12849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -11251,6 +12857,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -11258,6 +12865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -11265,6 +12873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -11272,6 +12881,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -11279,6 +12889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -11286,6 +12897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -11293,6 +12905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -11300,6 +12913,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -11307,6 +12921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -11314,6 +12929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -11321,6 +12937,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -11328,6 +12945,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -11335,6 +12953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -11342,6 +12961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -11349,6 +12969,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -11356,6 +12977,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -11363,6 +12985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -11370,6 +12993,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -11377,6 +13001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -11384,6 +13009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -11391,6 +13017,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -11398,6 +13025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -11405,6 +13033,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -11412,6 +13041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -11419,6 +13049,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -11426,6 +13057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -11433,6 +13065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -11440,6 +13073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -11447,6 +13081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -11454,6 +13089,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -11461,6 +13097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -11468,6 +13105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -11475,6 +13113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -11482,6 +13121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -11489,6 +13129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -11496,6 +13137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -11503,6 +13145,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -11510,6 +13153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -11517,6 +13161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -11524,6 +13169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -11531,6 +13177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -11538,6 +13185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -11545,6 +13193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -11552,6 +13201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -11559,6 +13209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -11566,6 +13217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -11573,6 +13225,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -11580,6 +13233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -11587,6 +13241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -11594,6 +13249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -11601,6 +13257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -11608,6 +13265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -11615,6 +13273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -11622,6 +13281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -11629,6 +13289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -11636,6 +13297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -11643,6 +13305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -11650,6 +13313,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -11657,6 +13321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -11664,6 +13329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -11671,6 +13337,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -11678,6 +13345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -11685,6 +13353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -11692,6 +13361,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -11699,6 +13369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -11706,6 +13377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -11713,6 +13385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -11720,6 +13393,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -11727,6 +13401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -11734,6 +13409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -11741,6 +13417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -11748,6 +13425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -11755,6 +13433,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -11762,6 +13441,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -11769,6 +13449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -11776,6 +13457,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -11783,6 +13465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -11790,6 +13473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -11797,6 +13481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -11804,6 +13489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -11811,6 +13497,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -11818,6 +13505,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -11825,6 +13513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -11832,6 +13521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -11839,6 +13529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -11846,6 +13537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -11853,6 +13545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -11860,6 +13553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -11867,6 +13561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -11874,6 +13569,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -11881,6 +13577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -11888,6 +13585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -11895,6 +13593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -11902,6 +13601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -11909,6 +13609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -11916,6 +13617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -11923,6 +13625,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -11930,6 +13633,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -11937,6 +13641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -11944,6 +13649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -11951,6 +13657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -11958,6 +13665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -11965,6 +13673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -11972,6 +13681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -11979,6 +13689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -11986,6 +13697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -11993,6 +13705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -12000,6 +13713,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -12007,6 +13721,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -12014,6 +13729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -12021,6 +13737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -12028,6 +13745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -12035,6 +13753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -12042,6 +13761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -12049,6 +13769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -12056,6 +13777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -12063,6 +13785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -12070,6 +13793,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -12077,6 +13801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -12084,6 +13809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -12091,6 +13817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -12098,6 +13825,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -12105,6 +13833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -12112,6 +13841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -12119,6 +13849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -12126,6 +13857,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -12133,6 +13865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -12140,6 +13873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -12147,6 +13881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -12154,6 +13889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -12161,6 +13897,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -12168,6 +13905,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -12175,6 +13913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -12182,6 +13921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -12189,6 +13929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -12196,6 +13937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -12203,6 +13945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -12210,6 +13953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -12217,6 +13961,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -12224,6 +13969,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -12231,6 +13977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -12238,6 +13985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -12245,6 +13993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -12252,6 +14001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -12259,6 +14009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -12266,6 +14017,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -12273,6 +14025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -12280,6 +14033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -12287,6 +14041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -12294,6 +14049,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -12301,6 +14057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -12308,6 +14065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -12315,6 +14073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -12322,6 +14081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -12329,6 +14089,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -12336,6 +14097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -12343,6 +14105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -12350,6 +14113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -12357,6 +14121,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -12364,6 +14129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -12371,6 +14137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -12378,6 +14145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -12385,6 +14153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -12392,6 +14161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -12399,6 +14169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -12406,6 +14177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -12413,6 +14185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -12420,6 +14193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -12427,6 +14201,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -12434,6 +14209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -12441,6 +14217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -12448,6 +14225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -12455,6 +14233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -12462,6 +14241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -12469,6 +14249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -12476,6 +14257,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -12483,6 +14265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -12490,6 +14273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -12497,6 +14281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -12504,6 +14289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -12511,6 +14297,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -12518,6 +14305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -12525,6 +14313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -12532,6 +14321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -12539,6 +14329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -12546,6 +14337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -12553,6 +14345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -12560,6 +14353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -12567,6 +14361,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -12574,6 +14369,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -12581,6 +14377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -12588,6 +14385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -12595,6 +14393,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -12602,6 +14401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -12609,6 +14409,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -12616,6 +14417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -12623,6 +14425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -12630,6 +14433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -12637,6 +14441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -12644,6 +14449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -12651,6 +14457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -12658,6 +14465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -12665,6 +14473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -12672,6 +14481,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -12679,6 +14489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -12686,6 +14497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -12693,6 +14505,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -12700,6 +14513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -12707,6 +14521,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -12714,6 +14529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -12721,6 +14537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -12728,6 +14545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -12735,6 +14553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -12742,6 +14561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -12749,6 +14569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -12756,6 +14577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -12763,6 +14585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -12770,6 +14593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -12777,6 +14601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -12784,6 +14609,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -12791,6 +14617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -12798,6 +14625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -12805,6 +14633,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -12812,6 +14641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -12819,6 +14649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -12826,6 +14657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -12833,6 +14665,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -12840,6 +14673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -12847,6 +14681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -12854,6 +14689,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -12861,6 +14697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -12868,6 +14705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -12875,6 +14713,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -12882,6 +14721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -12889,6 +14729,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -12896,6 +14737,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -12903,6 +14745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -12910,6 +14753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -12917,6 +14761,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -12924,6 +14769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -12931,6 +14777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -12938,6 +14785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -12945,6 +14793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -12952,6 +14801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -12959,6 +14809,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -12966,6 +14817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -12973,6 +14825,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -12980,6 +14833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -12987,6 +14841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -12994,6 +14849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -13001,6 +14857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -13008,6 +14865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -13015,6 +14873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -13022,6 +14881,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -13029,6 +14889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -13036,6 +14897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -13043,6 +14905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -13050,6 +14913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -13057,6 +14921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -13064,6 +14929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -13071,6 +14937,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -13078,6 +14945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -13085,6 +14953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -13092,6 +14961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -13099,6 +14969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -13106,6 +14977,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -13113,6 +14985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -13120,6 +14993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -13127,6 +15001,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -13134,6 +15009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -13141,6 +15017,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -13148,6 +15025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -13155,6 +15033,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -13162,6 +15041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -13169,6 +15049,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -13176,6 +15057,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -13183,6 +15065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -13190,6 +15073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -13197,6 +15081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -13204,6 +15089,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -13211,6 +15097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -13218,6 +15105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -13225,6 +15113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -13232,6 +15121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -13239,6 +15129,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -13246,6 +15137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -13253,6 +15145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -13260,6 +15153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -13267,6 +15161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -13274,6 +15169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -13281,6 +15177,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -13288,6 +15185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -13295,6 +15193,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -13302,6 +15201,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -13309,6 +15209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -13316,6 +15217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -13323,6 +15225,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -13330,6 +15233,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -13337,6 +15241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -13344,6 +15249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -13351,6 +15257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -13358,6 +15265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -13365,6 +15273,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -13372,6 +15281,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -13379,6 +15289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -13386,6 +15297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -13393,6 +15305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -13400,6 +15313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -13407,6 +15321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -13414,6 +15329,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -13421,6 +15337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -13428,6 +15345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -13435,6 +15353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -13442,6 +15361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -13449,6 +15369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -13456,6 +15377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -13463,6 +15385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -13470,6 +15393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -13477,6 +15401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -13484,6 +15409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -13491,6 +15417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -13498,6 +15425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -13505,6 +15433,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -13512,6 +15441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -13519,6 +15449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -13526,6 +15457,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -13533,6 +15465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -13540,6 +15473,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -13547,6 +15481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -13554,6 +15489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -13561,6 +15497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -13568,6 +15505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -13575,6 +15513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -13582,6 +15521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -13589,6 +15529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -13596,6 +15537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -13603,6 +15545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -13610,6 +15553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -13617,6 +15561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -13624,6 +15569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -13631,6 +15577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -13638,6 +15585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -13645,6 +15593,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -13652,6 +15601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -13659,6 +15609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -13666,6 +15617,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -13673,6 +15625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -13680,6 +15633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -13687,6 +15641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -13694,6 +15649,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -13701,6 +15657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -13708,6 +15665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -13715,6 +15673,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -13722,6 +15681,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -13729,6 +15689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -13736,6 +15697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -13743,6 +15705,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -13750,6 +15713,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -13757,6 +15721,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -13764,6 +15729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -13771,6 +15737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -13778,6 +15745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -13785,6 +15753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -13792,6 +15761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -13799,6 +15769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -13806,6 +15777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -13813,6 +15785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -13820,6 +15793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -13827,6 +15801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -13834,6 +15809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -13841,6 +15817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -13848,6 +15825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -13855,6 +15833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -13862,6 +15841,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -13869,6 +15849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -13876,6 +15857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -13883,6 +15865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -13890,6 +15873,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -13897,6 +15881,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -13904,6 +15889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -13911,6 +15897,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -13918,6 +15905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -13925,6 +15913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -13932,6 +15921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -13939,6 +15929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -13946,6 +15937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -13953,6 +15945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -13960,6 +15953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -13967,6 +15961,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -13974,6 +15969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -13981,6 +15977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -13988,6 +15985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -13995,6 +15993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -14002,6 +16001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -14009,6 +16009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -14016,6 +16017,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -14023,6 +16025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -14030,6 +16033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -14037,6 +16041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -14044,6 +16049,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -14051,6 +16057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -14058,6 +16065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -14065,6 +16073,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -14072,6 +16081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -14079,6 +16089,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -14086,6 +16097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -14093,6 +16105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -14100,6 +16113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -14107,6 +16121,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -14114,6 +16129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -14121,6 +16137,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -14128,6 +16145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -14135,6 +16153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -14142,6 +16161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -14149,6 +16169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -14156,6 +16177,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -14163,6 +16185,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -14170,6 +16193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -14177,6 +16201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -14184,6 +16209,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -14191,6 +16217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -14198,6 +16225,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -14205,6 +16233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -14212,6 +16241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -14219,6 +16249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -14226,6 +16257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -14233,6 +16265,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -14240,6 +16273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -14247,6 +16281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -14254,6 +16289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -14261,6 +16297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -14268,6 +16305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -14275,6 +16313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -14282,6 +16321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -14289,6 +16329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -14296,6 +16337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -14303,6 +16345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -14310,6 +16353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -14317,6 +16361,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -14324,6 +16369,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -14331,6 +16377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -14338,6 +16385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -14345,6 +16393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -14352,6 +16401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -14359,6 +16409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -14366,6 +16417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -14373,6 +16425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -14380,6 +16433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -14387,6 +16441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -14394,6 +16449,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -14401,6 +16457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -14408,6 +16465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -14415,6 +16473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -14422,6 +16481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -14429,6 +16489,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -14436,6 +16497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -14443,6 +16505,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -14450,6 +16513,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -14457,6 +16521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -14464,6 +16529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -14471,6 +16537,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -14478,6 +16545,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -14485,6 +16553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -14492,6 +16561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -14499,6 +16569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -14506,6 +16577,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -14513,6 +16585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -14520,6 +16593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -14527,6 +16601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -14534,6 +16609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -14541,6 +16617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -14548,6 +16625,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -14555,6 +16633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -14562,6 +16641,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -14569,6 +16649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -14576,6 +16657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -14583,6 +16665,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -14590,6 +16673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -14597,6 +16681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -14604,6 +16689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -14611,6 +16697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -14618,6 +16705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -14625,6 +16713,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -14632,6 +16721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -14639,6 +16729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -14646,6 +16737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -14653,6 +16745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -14660,6 +16753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -14667,6 +16761,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -14674,6 +16769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -14681,6 +16777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -14688,6 +16785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -14695,6 +16793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -14702,6 +16801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -14709,6 +16809,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -14716,6 +16817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -14723,6 +16825,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -14730,6 +16833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -14737,6 +16841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -14744,6 +16849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -14751,6 +16857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -14758,6 +16865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -14765,6 +16873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -14772,6 +16881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -14779,6 +16889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -14786,6 +16897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -14793,6 +16905,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -14800,6 +16913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -14807,6 +16921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -14814,6 +16929,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -14821,6 +16937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -14828,6 +16945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -14835,6 +16953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -14842,6 +16961,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -14849,6 +16969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -14856,6 +16977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -14863,6 +16985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -14870,6 +16993,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -14877,6 +17001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -14884,6 +17009,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -14891,6 +17017,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -14898,6 +17025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -14905,6 +17033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -14912,6 +17041,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -14919,6 +17049,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -14926,6 +17057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -14933,6 +17065,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -14940,6 +17073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -14947,6 +17081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -14954,6 +17089,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -14961,6 +17097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -14968,6 +17105,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -14975,6 +17113,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -14982,6 +17121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -14989,6 +17129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -14996,6 +17137,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -15003,6 +17145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -15010,6 +17153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -15017,6 +17161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -15024,6 +17169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -15031,6 +17177,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -15038,6 +17185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -15045,6 +17193,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -15052,6 +17201,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -15059,6 +17209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -15066,6 +17217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -15073,6 +17225,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -15080,6 +17233,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -15087,6 +17241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -15094,6 +17249,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -15101,6 +17257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -15108,6 +17265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -15115,6 +17273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -15122,6 +17281,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -15129,6 +17289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -15136,6 +17297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -15143,6 +17305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -15150,6 +17313,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -15157,6 +17321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -15164,6 +17329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -15171,6 +17337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -15178,6 +17345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -15185,6 +17353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -15192,6 +17361,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -15199,6 +17369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -15206,6 +17377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -15213,6 +17385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -15220,6 +17393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -15227,6 +17401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -15234,6 +17409,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -15241,6 +17417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -15248,6 +17425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -15255,6 +17433,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -15262,6 +17441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -15269,6 +17449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -15276,6 +17457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -15283,6 +17465,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -15290,6 +17473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -15297,6 +17481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -15304,6 +17489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -15311,6 +17497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -15318,6 +17505,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -15325,6 +17513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -15332,6 +17521,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -15339,6 +17529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -15346,6 +17537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -15353,6 +17545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -15360,6 +17553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -15367,6 +17561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -15374,6 +17569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -15381,6 +17577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -15388,6 +17585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -15395,6 +17593,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -15402,6 +17601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -15409,6 +17609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -15416,6 +17617,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -15423,6 +17625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -15430,6 +17633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -15437,6 +17641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -15444,6 +17649,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -15451,6 +17657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -15458,6 +17665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -15465,6 +17673,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -15472,6 +17681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -15479,6 +17689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -15486,6 +17697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -15493,6 +17705,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -15500,6 +17713,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -15507,6 +17721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -15514,6 +17729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -15521,6 +17737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -15528,6 +17745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -15535,6 +17753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -15542,6 +17761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -15549,6 +17769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -15556,6 +17777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -15563,6 +17785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -15570,6 +17793,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -15577,6 +17801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -15584,6 +17809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -15591,6 +17817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -15598,6 +17825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -15605,6 +17833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -15612,6 +17841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -15619,6 +17849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -15626,6 +17857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -15633,6 +17865,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -15640,6 +17873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -15647,6 +17881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -15654,6 +17889,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -15661,6 +17897,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -15668,6 +17905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -15675,6 +17913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -15682,6 +17921,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -15689,6 +17929,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -15696,6 +17937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -15703,6 +17945,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -15710,6 +17953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -15717,6 +17961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -15724,6 +17969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -15731,6 +17977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -15738,6 +17985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -15745,6 +17993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -15752,6 +18001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -15759,6 +18009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -15766,6 +18017,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -15773,6 +18025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -15780,6 +18033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -15787,6 +18041,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -15794,6 +18049,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -15801,6 +18057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -15808,6 +18065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -15815,6 +18073,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -15822,6 +18081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -15829,6 +18089,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -15836,6 +18097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -15843,6 +18105,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -15850,6 +18113,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -15857,6 +18121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -15864,6 +18129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -15871,6 +18137,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -15878,6 +18145,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -15885,6 +18153,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -15892,6 +18161,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -15899,6 +18169,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -15906,6 +18177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -15913,6 +18185,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -15920,6 +18193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -15927,6 +18201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -15934,6 +18209,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -15941,6 +18217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -15948,6 +18225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -15955,6 +18233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -15962,6 +18241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -15969,6 +18249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -15976,6 +18257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -15983,6 +18265,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -15990,6 +18273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -15997,6 +18281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -16004,6 +18289,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -16011,6 +18297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -16018,6 +18305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -16025,6 +18313,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -16032,6 +18321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -16039,6 +18329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -16046,6 +18337,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -16053,6 +18345,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -16060,6 +18353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -16067,6 +18361,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -16074,6 +18369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -16081,6 +18377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -16088,6 +18385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -16095,6 +18393,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -16102,6 +18401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -16109,6 +18409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -16116,6 +18417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -16123,6 +18425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -16130,6 +18433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -16137,6 +18441,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -16144,6 +18449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -16151,6 +18457,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -16158,6 +18465,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -16165,6 +18473,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -16172,6 +18481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -16179,6 +18489,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -16186,6 +18497,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -16193,6 +18505,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -16200,6 +18513,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -16207,6 +18521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -16214,6 +18529,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -16221,6 +18537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -16228,6 +18545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -16235,6 +18553,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -16242,6 +18561,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -16249,6 +18569,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -16256,6 +18577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -16263,6 +18585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -16270,6 +18593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -16277,6 +18601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -16284,6 +18609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -16291,6 +18617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -16298,6 +18625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -16305,6 +18633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -16312,6 +18641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -16319,6 +18649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -16326,6 +18657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -16333,6 +18665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -16340,6 +18673,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -16347,6 +18681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -16354,6 +18689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -16361,6 +18697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -16368,6 +18705,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -16375,6 +18713,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -16382,6 +18721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -16389,6 +18729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -16396,6 +18737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -16403,6 +18745,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -16410,6 +18753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -16417,6 +18761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -16424,6 +18769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -16431,6 +18777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -16438,6 +18785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -16445,6 +18793,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -16452,6 +18801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -16459,6 +18809,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -16466,6 +18817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -16473,6 +18825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -16480,6 +18833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -16487,6 +18841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -16494,6 +18849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -16501,6 +18857,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -16508,6 +18865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -16515,6 +18873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -16522,6 +18881,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -16529,6 +18889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -16536,6 +18897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -16543,6 +18905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -16550,6 +18913,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -16557,6 +18921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -16564,6 +18929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -16571,6 +18937,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -16578,6 +18945,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -16585,6 +18953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -16592,6 +18961,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -16599,6 +18969,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -16606,6 +18977,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -16613,6 +18985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -16620,6 +18993,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -16627,6 +19001,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -16634,6 +19009,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -16641,6 +19017,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -16648,6 +19025,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -16655,6 +19033,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -16662,6 +19041,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -16669,6 +19049,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -16676,6 +19057,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -16683,6 +19065,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -16690,6 +19073,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -16697,6 +19081,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -16704,6 +19089,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -16711,6 +19097,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -16718,6 +19105,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -16725,6 +19113,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -16732,6 +19121,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -16739,6 +19129,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -16746,6 +19137,7 @@ layers {
     tile: 29
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -16753,6 +19145,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -16760,6 +19153,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -16767,6 +19161,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -16774,6 +19169,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -16781,6 +19177,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -16788,6 +19185,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -16795,6 +19193,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -16802,6 +19201,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -16809,6 +19209,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -16816,6 +19217,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -16823,6 +19225,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -16830,6 +19233,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -16837,6 +19241,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -16844,6 +19249,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -16851,6 +19257,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -16858,6 +19265,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -16865,6 +19273,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -16872,6 +19281,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -16879,6 +19289,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -16886,6 +19297,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -16893,6 +19305,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -16900,6 +19313,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -16907,6 +19321,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -16914,6 +19329,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -16921,6 +19337,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -16928,6 +19345,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -16935,6 +19353,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -16942,6 +19361,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -16949,6 +19369,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -16956,6 +19377,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -16963,6 +19385,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -16970,6 +19393,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -16977,6 +19401,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -16984,6 +19409,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -16991,6 +19417,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -16998,6 +19425,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -17005,6 +19433,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -17012,6 +19441,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -17019,6 +19449,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -17026,6 +19457,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -17033,6 +19465,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -17040,6 +19473,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -17047,6 +19481,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -17054,6 +19489,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -17061,6 +19497,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -17068,6 +19505,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -17075,6 +19513,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -17082,6 +19521,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -17089,6 +19529,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -17096,6 +19537,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -17103,6 +19545,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -17110,6 +19553,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -17117,6 +19561,7 @@ layers {
     tile: 100
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -17124,6 +19569,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -17131,6 +19577,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -17138,6 +19585,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 0
@@ -17145,6 +19593,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 1
@@ -17152,6 +19601,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -17159,6 +19609,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -17166,6 +19617,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -17173,6 +19625,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -17180,6 +19633,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -17187,6 +19641,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -17194,6 +19649,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 8
@@ -17201,6 +19657,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -17208,6 +19665,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -17215,6 +19673,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -17222,6 +19681,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -17229,6 +19689,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -17236,6 +19697,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -17243,6 +19705,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -17250,6 +19713,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 16
@@ -17257,6 +19721,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -17264,6 +19729,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -17271,6 +19737,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -17278,6 +19745,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -17285,6 +19753,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 21
@@ -17292,6 +19761,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -17299,6 +19769,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -17306,6 +19777,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -17313,6 +19785,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -17320,6 +19793,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -17327,6 +19801,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -17334,6 +19809,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -17341,6 +19817,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -17348,6 +19825,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -17355,6 +19833,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -17362,6 +19841,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -17369,6 +19849,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -17376,6 +19857,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -17383,6 +19865,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -17390,6 +19873,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -17397,6 +19881,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 37
@@ -17404,6 +19889,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 38
@@ -17411,6 +19897,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 39
@@ -17418,6 +19905,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 40
@@ -17425,6 +19913,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 41
@@ -17432,6 +19921,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -17439,6 +19929,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -17446,6 +19937,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -17453,6 +19945,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -17460,6 +19953,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -17467,6 +19961,7 @@ layers {
     tile: 101
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -17474,6 +19969,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -17481,6 +19977,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 49
@@ -17488,6 +19985,7 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 50
@@ -17495,11 +19993,12 @@ layers {
     tile: 28
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
 }
 layers {
   id: "layer2"
-  z: 0.1
+  z: 0.2
   is_visible: 1
   cell {
     x: 4
@@ -17507,6 +20006,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -17514,6 +20014,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -17521,6 +20022,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -17528,6 +20030,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -17535,6 +20038,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -17542,6 +20046,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -17549,6 +20054,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -17556,6 +20062,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -17563,6 +20070,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -17570,6 +20078,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -17577,6 +20086,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -17584,6 +20094,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -17591,6 +20102,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -17598,6 +20110,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -17605,6 +20118,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -17612,6 +20126,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -17619,6 +20134,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 27
@@ -17626,6 +20142,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 28
@@ -17633,6 +20150,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 29
@@ -17640,6 +20158,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -17647,6 +20166,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -17654,6 +20174,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -17661,6 +20182,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -17668,6 +20190,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -17675,6 +20198,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -17682,6 +20206,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -17689,6 +20214,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -17696,6 +20222,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -17703,6 +20230,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -17710,6 +20238,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -17717,6 +20246,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -17724,6 +20254,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -17731,6 +20262,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -17738,6 +20270,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -17745,6 +20278,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 15
@@ -17752,6 +20286,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -17759,6 +20294,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -17766,6 +20302,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -17773,6 +20310,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -17780,6 +20318,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -17787,6 +20326,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -17794,6 +20334,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -17801,6 +20342,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -17808,6 +20350,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -17815,6 +20358,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -17822,6 +20366,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -17829,6 +20374,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -17836,6 +20382,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -17843,6 +20390,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -17850,6 +20398,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -17857,6 +20406,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -17864,6 +20414,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 22
@@ -17871,6 +20422,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -17878,6 +20430,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -17885,6 +20438,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -17892,6 +20446,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -17899,6 +20454,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -17906,6 +20462,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -17913,6 +20470,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -17920,6 +20478,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 2
@@ -17927,6 +20486,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 3
@@ -17934,6 +20494,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -17941,6 +20502,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -17948,6 +20510,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -17955,6 +20518,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -17962,6 +20526,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -17969,6 +20534,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -17976,6 +20542,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -17983,6 +20550,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 34
@@ -17990,6 +20558,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 35
@@ -17997,6 +20566,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 36
@@ -18004,6 +20574,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -18011,6 +20582,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -18018,6 +20590,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -18025,6 +20598,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -18032,6 +20606,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -18039,6 +20614,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -18046,6 +20622,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -18053,6 +20630,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -18060,6 +20638,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -18067,6 +20646,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -18074,6 +20654,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -18081,6 +20662,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -18088,6 +20670,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 9
@@ -18095,6 +20678,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 10
@@ -18102,6 +20686,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -18109,6 +20694,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -18116,6 +20702,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 23
@@ -18123,6 +20710,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 24
@@ -18130,6 +20718,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 25
@@ -18137,6 +20726,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 26
@@ -18144,6 +20734,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 42
@@ -18151,6 +20742,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 43
@@ -18158,6 +20750,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 44
@@ -18165,6 +20758,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -18172,6 +20766,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -18179,6 +20774,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -18186,6 +20782,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -18193,6 +20790,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -18200,6 +20798,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 11
@@ -18207,6 +20806,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 12
@@ -18214,6 +20814,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 13
@@ -18221,6 +20822,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 14
@@ -18228,6 +20830,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -18235,6 +20838,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -18242,6 +20846,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -18249,6 +20854,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -18256,6 +20862,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -18263,6 +20870,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -18270,6 +20878,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -18277,6 +20886,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -18284,6 +20894,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 4
@@ -18291,6 +20902,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 5
@@ -18298,6 +20910,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 6
@@ -18305,6 +20918,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 7
@@ -18312,6 +20926,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 30
@@ -18319,6 +20934,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 31
@@ -18326,6 +20942,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 32
@@ -18333,6 +20950,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 33
@@ -18340,6 +20958,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -18347,6 +20966,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -18354,6 +20974,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -18361,6 +20982,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -18368,6 +20990,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -18375,6 +20998,7 @@ layers {
     tile: 74
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -18382,6 +21006,7 @@ layers {
     tile: 75
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -18389,6 +21014,7 @@ layers {
     tile: 76
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -18396,6 +21022,7 @@ layers {
     tile: 77
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 17
@@ -18403,6 +21030,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 18
@@ -18410,6 +21038,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 19
@@ -18417,6 +21046,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 20
@@ -18424,6 +21054,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 45
@@ -18431,6 +21062,7 @@ layers {
     tile: 50
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 46
@@ -18438,6 +21070,7 @@ layers {
     tile: 51
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 47
@@ -18445,6 +21078,7 @@ layers {
     tile: 52
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
   cell {
     x: 48
@@ -18452,6 +21086,7 @@ layers {
     tile: 53
     h_flip: 0
     v_flip: 0
+    rotate90: 0
   }
 }
 material: "/builtins/materials/tile_map.material"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
+        "@ts-defold/library": "^0.1.1",
         "@ts-defold/tstl-export-as-global": "^1.0.1",
         "@ts-defold/tstl-userdata-sugar": "^1.0.1",
         "@ts-defold/types": "^1.2.20",
@@ -155,6 +156,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@ts-defold/library": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@ts-defold/library/-/library-0.1.3.tgz",
+      "integrity": "sha512-aNEKLJSktghVyOcZBe4XhkyDo5NXsX3yZU1ksF3RqKYRyzsORYwrFknxzAQVS4GzCOIng0maePjgfHqm8Gb1yA==",
+      "dev": true,
+      "dependencies": {
+        "adm-zip": "^0.5.9",
+        "await-to-js": "^3.0.0",
+        "node-fetch": "^2.6.1",
+        "semver": "^7.3.5",
+        "xml2js": "^0.4.23",
+        "yargs": "^17.2.1"
+      },
+      "bin": {
+        "library": "bin/library.js"
+      },
+      "peerDependencies": {
+        "typescript-to-lua": "^1.1.1"
       }
     },
     "node_modules/@ts-defold/tstl-export-as-global": {
@@ -420,6 +441,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -475,6 +505,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/await-to-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-3.0.0.tgz",
+      "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -526,6 +565,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -613,6 +666,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
@@ -624,6 +683,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1142,6 +1210,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1318,6 +1395,26 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/normalize-path": {
       "version": "2.1.1",
@@ -1497,6 +1594,15 @@
       "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
       "dev": true
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -1583,6 +1689,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/sax": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
+      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
+      "dev": true
+    },
     "node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -1635,6 +1747,20 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -1711,6 +1837,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/tslib": {
       "version": "1.14.1",
@@ -1851,6 +1983,22 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1866,17 +2014,101 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,18 +50,18 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -82,22 +82,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@ts-defold/types": {
-      "version": "1.2.21",
-      "resolved": "https://registry.npmjs.org/@ts-defold/types/-/types-1.2.21.tgz",
-      "integrity": "sha512-2OEO28D2Kz8ozz7onqHiZE8yGneVmXDt8EpZcgT3MR5EzduJk7hUBWWufabiAnvM+x2NzvBpNeZcsZpq3zoC6A==",
+      "version": "1.2.40",
+      "resolved": "https://registry.npmjs.org/@ts-defold/types/-/types-1.2.40.tgz",
+      "integrity": "sha512-sXPjLNIAN0+CMNSNqmRhkWSehvVyJxHJ2t1JxmTYcgAQCzCuXom/nanjF3gEo4ABRwH3r9c7AWW3duebed1ONQ==",
       "dev": true,
       "dependencies": {
         "lua-types": "^2.10.1"
@@ -215,15 +215,15 @@
       }
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.12",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
-      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
     "node_modules/@types/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.7.tgz",
+      "integrity": "sha512-/wdoPq1QqkSj9/QOeKkFquEuPzQbHTWAMPH/PaUMB+JuR31lXhlWXRZ52IpfDYVlDOUBvX09uBrPwxGT1hjNBg==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -420,10 +420,16 @@
       "integrity": "sha512-GtmhFqyg+txpGgGLM3mlS3R6AEG9MQhKALxxcbr6SBzg9u7YAXcPKqUBaBYd6nH+Pi/eQLcWz4BNOLhz8v4TjQ==",
       "dev": true
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -707,27 +713,28 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-      "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.56.0",
+        "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -737,7 +744,6 @@
         "globals": "^13.19.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
@@ -749,7 +755,6 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
@@ -776,9 +781,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -788,9 +793,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -813,9 +818,9 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-      "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.9.0",
@@ -896,9 +901,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -936,9 +941,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -985,12 +990,13 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
@@ -998,9 +1004,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
     "node_modules/fs.realpath": {
@@ -1010,10 +1016,13 @@
       "dev": true
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "1.0.3",
@@ -1066,9 +1075,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1112,18 +1121,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1133,10 +1130,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -1190,12 +1199,12 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1267,6 +1276,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1278,6 +1293,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -1560,9 +1584,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1604,12 +1628,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -1696,9 +1720,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -1851,12 +1875,12 @@
       "dev": true
     },
     "node_modules/tstl-trim-extensions": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tstl-trim-extensions/-/tstl-trim-extensions-1.0.3.tgz",
-      "integrity": "sha512-P9jmoAdEpGK5vZ73yI3GxgaMgVzkTPbosyHh3q7nT0K0U86x9DUlQoB4Gb6fI+MsuGDfTndel0Jf8IUCK2aMvg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tstl-trim-extensions/-/tstl-trim-extensions-1.0.4.tgz",
+      "integrity": "sha512-z72H57fPzzTMAjWbCTH/R3LjrT9iJUaPMqPY+sAts7i/oIR6SpptWGa8VK6t9NpKNvRku1SKbDW5/NNcoN5+Qw==",
       "dev": true,
       "peerDependencies": {
-        "typescript-to-lua": "^1.5.0"
+        "typescript-to-lua": ">=1.5.0"
       }
     },
     "node_modules/tsutils": {

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "node": ">=14.17.0"
   },
   "scripts": {
+    "resolve": "library resolve",
     "build": "tstl",
     "lint": "eslint src",
     "dev": "tstl --watch"
   },
   "devDependencies": {
+    "@ts-defold/library": "^0.1.1",
     "@ts-defold/tstl-export-as-global": "^1.0.1",
     "@ts-defold/tstl-userdata-sugar": "^1.0.1",
     "@ts-defold/types": "^1.2.20",

--- a/src/scripts/player.script.ts
+++ b/src/scripts/player.script.ts
@@ -46,19 +46,19 @@ export function update(this: props, dt: number): void {
 }
 
 export function on_input(this: props, actionId: hash, action: action): void {
-    if (actionId == hash("up")) {
+    if (actionId === hash("up")) {
         this.input.y = 1;
     }
-    else if (actionId == hash("down")) {
+    else if (actionId === hash("down")) {
         this.input.y = -1;
     }
-    else if (actionId == hash("left")) {
+    else if (actionId === hash("left")) {
         this.input.x = -1;
     }
-    else if (actionId == hash("right")) {
+    else if (actionId === hash("right")) {
         this.input.x = 1;
     }
-    else if (actionId == hash("fire") && action.pressed) {
+    else if (actionId === hash("fire") && action.pressed) {
         this.firing = true;
     }
 

--- a/src/scripts/rocket.script.ts
+++ b/src/scripts/rocket.script.ts
@@ -22,10 +22,10 @@ export function update(this: props, dt:number): void {
 }
 
 export function on_message(this: props, messageId: hash, message: {other_id: hash}, _sender: url): void {
-    if (messageId == hash("animation_done")) {
+    if (messageId === hash("animation_done")) {
         go.delete();
     }
-    else if (messageId == hash("collision_response")) {
+    else if (messageId === hash("collision_response")) {
         explode(this);
         go.delete(message.other_id);
         msg.post("/gui#ui", "add_score", {score: 100});

--- a/src/scripts/ui.gui_script.ts
+++ b/src/scripts/ui.gui_script.ts
@@ -7,7 +7,7 @@ export function init(this: props): void {
 }
 
 export function on_message(this: props, messageId: hash, message: {score: number}, _sender: url): void {
-    if (messageId == hash("add_score")) {
+    if (messageId === hash("add_score")) {
         this.score += message.score;
         const scoreNode = gui.get_node("score");
         gui.set_text(scoreNode, `SCORE: ${this.score}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
         "lib": ["es2019"],
         "module": "commonjs",
         "esModuleInterop": true,
-        "experimentalDecorators": true,
         "moduleResolution": "node",
         "types": ["types", "language-extensions"],
         "typeRoots": [


### PR DESCRIPTION
- Also bumps up the minimum Z value of the tilemap to 0.1. This seems to fix a problem with the newer default render script that made the lower layer invisible.