### PR TITLE
chore: upgrade to sparse file formats

### DIFF
--- a/app/main/main.collection
+++ b/app/main/main.collection
@@ -5,18 +5,6 @@ instances {
   position {
     x: 147.0
     y: 552.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
   }
 }
 instances {
@@ -25,18 +13,6 @@ instances {
   position {
     x: 239.0
     y: 88.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
   }
 }
 instances {
@@ -45,18 +21,6 @@ instances {
   position {
     x: 502.0
     y: 658.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
   }
 }
 instances {
@@ -65,18 +29,6 @@ instances {
   position {
     x: 577.0
     y: 286.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
   }
 }
 scale_along_z: 0
@@ -86,105 +38,38 @@ embedded_instances {
   "  id: \"map\"\n"
   "  component: \"/main/map.tilemap\"\n"
   "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
   "    z: -1.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
   "  }\n"
   "}\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-  }
 }
 embedded_instances {
   id: "player"
   data: "components {\n"
   "  id: \"player\"\n"
   "  component: \"/scripts/player.script\"\n"
-  "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
-  "  }\n"
   "}\n"
   "embedded_components {\n"
   "  id: \"sprite\"\n"
   "  type: \"sprite\"\n"
-  "  data: \"tile_set: \\\"/main/sprites.atlas\\\"\\n"
-  "default_animation: \\\"player-down\\\"\\n"
+  "  data: \"default_animation: \\\"player-down\\\"\\n"
   "material: \\\"/builtins/materials/sprite.material\\\"\\n"
-  "blend_mode: BLEND_MODE_ALPHA\\n"
+  "textures {\\n"
+  "  sampler: \\\"texture_sampler\\\"\\n"
+  "  texture: \\\"/main/sprites.atlas\\\"\\n"
+  "}\\n"
   "\"\n"
-  "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
-  "  }\n"
   "}\n"
   "embedded_components {\n"
   "  id: \"rocketfactory\"\n"
   "  type: \"factory\"\n"
   "  data: \"prototype: \\\"/main/rocket.go\\\"\\n"
-  "load_dynamically: false\\n"
   "\"\n"
-  "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
-  "  }\n"
   "}\n"
   ""
   position {
     x: 389.0
     y: 363.0
-    z: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
     z: 1.0
   }
 }
@@ -193,33 +78,6 @@ embedded_instances {
   data: "components {\n"
   "  id: \"ui\"\n"
   "  component: \"/main/ui.gui\"\n"
-  "  position {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "  }\n"
-  "  rotation {\n"
-  "    x: 0.0\n"
-  "    y: 0.0\n"
-  "    z: 0.0\n"
-  "    w: 1.0\n"
-  "  }\n"
   "}\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale3 {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-  }
 }

--- a/app/main/map.tilemap
+++ b/app/main/map.tilemap
@@ -2,21092 +2,13184 @@ tile_set: "/main/map.tilesource"
 layers {
   id: "layer1"
   z: 0.1
-  is_visible: 1
   cell {
     x: 0
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 0
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 0
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 0
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 0
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 1
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 1
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 1
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 1
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 1
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 1
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 1
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 1
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 1
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 2
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 2
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 2
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 2
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 2
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 2
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 2
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 2
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 2
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 2
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 2
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 2
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 2
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 2
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 3
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 3
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 3
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 3
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 3
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 3
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 3
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 3
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 3
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 3
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 3
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 3
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 3
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 3
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 3
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 4
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 4
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 4
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 4
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 4
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 4
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 4
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 4
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 4
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 4
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 4
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 4
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 4
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 4
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 4
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 4
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 4
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 4
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 4
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 4
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 5
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 5
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 5
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 5
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 5
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 5
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 5
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 5
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 5
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 5
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 5
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 5
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 5
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 6
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 6
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 6
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 6
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 6
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 6
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 6
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 6
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 6
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 6
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 6
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 7
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 7
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 7
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 7
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 7
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 7
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 7
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 7
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 7
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 7
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 7
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 7
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 7
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 8
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 8
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 8
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 8
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 8
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 8
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 8
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 9
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 9
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 9
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 9
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 9
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 9
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 9
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 9
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 9
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 9
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 9
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 9
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 9
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 9
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 9
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 9
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 9
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 9
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 10
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 10
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 10
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 10
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 10
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 10
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 10
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 10
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 10
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 10
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 10
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 10
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 10
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 10
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 10
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 10
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 10
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 10
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 11
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 11
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 11
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 11
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 11
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 11
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 11
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 11
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 11
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 11
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 11
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 12
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 12
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 12
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 12
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 12
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 12
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 12
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 12
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 12
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 12
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 12
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 12
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 12
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 12
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 12
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 12
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 12
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 12
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 13
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 13
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 13
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 13
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 13
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 13
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 13
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 13
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 13
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 13
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 13
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 13
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 13
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 13
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 14
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 14
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 14
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 14
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 14
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 14
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 14
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 14
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 14
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 15
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 15
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 15
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 15
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 15
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 15
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 15
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 15
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 15
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 15
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 15
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 15
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 15
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 15
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 16
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 16
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 16
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 16
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 16
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 16
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 16
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 16
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 16
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 16
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 16
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 16
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 16
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 16
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 16
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 16
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 17
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 17
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 17
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 17
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 17
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 17
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 17
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 17
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 17
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 17
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 17
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 17
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 17
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 17
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 17
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 17
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 17
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 18
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 18
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 18
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 18
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 18
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 18
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 18
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 18
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 18
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 18
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 18
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 18
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 18
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 18
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 18
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 19
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 19
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 19
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 19
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 19
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 19
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 19
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 19
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 19
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 19
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 19
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 19
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 19
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 20
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 20
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 20
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 20
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 20
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 20
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 20
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 20
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 20
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 20
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 20
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 20
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 20
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 21
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 21
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 21
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 21
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 21
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 21
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 21
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 21
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 22
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 22
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 22
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 22
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 22
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 22
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 22
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 22
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 22
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 22
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 22
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 23
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 23
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 23
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 23
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 23
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 23
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 23
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 23
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 23
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 23
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 23
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 23
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 23
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 23
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 24
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 24
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 24
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 24
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 24
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 24
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 24
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 24
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 24
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 24
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 24
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 24
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 24
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 24
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 24
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 24
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 25
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 25
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 25
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 25
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 25
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 25
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 25
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 25
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 25
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 25
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 25
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 25
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 25
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 25
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 25
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 25
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 25
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 26
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 26
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 26
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 26
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 26
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 26
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 26
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 26
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 26
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 26
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 26
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 26
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 26
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 27
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 27
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 27
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 27
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 27
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 27
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 27
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 27
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 27
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 27
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 27
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 27
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 28
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 28
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 28
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 28
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 28
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 28
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 28
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 28
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 28
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 28
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 28
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 28
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 29
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 29
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 29
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 29
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 29
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 29
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 29
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 29
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 29
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 29
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 29
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 30
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 30
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 30
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 30
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 30
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 30
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 30
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 30
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 30
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 30
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 30
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 30
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 30
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 30
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 30
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 30
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 30
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 30
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 30
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 30
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 30
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 31
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 31
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 31
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 31
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 31
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 31
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 31
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 31
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 31
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 31
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 31
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 31
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 31
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 31
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 31
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 31
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 32
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 32
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 32
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 32
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 32
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 32
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 32
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 32
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 32
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 32
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 33
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 33
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 33
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 33
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 33
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 33
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 33
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 33
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 33
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 33
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 34
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 34
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 34
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 34
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 34
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 34
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 34
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 34
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 34
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 34
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 35
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 35
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 35
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 35
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 35
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 35
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 35
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 35
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 35
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 35
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 35
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 35
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 35
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 36
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 36
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 36
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 36
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 36
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 36
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 36
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 36
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 36
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 36
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 36
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 36
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 36
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 36
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 37
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 37
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 37
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 37
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 37
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 37
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 37
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 37
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 37
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 37
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 37
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 37
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 37
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 38
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 38
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 38
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 38
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 38
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 38
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 38
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 38
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 38
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 38
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 38
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 38
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 39
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 39
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 39
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 39
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 39
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 39
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 39
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 39
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 39
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 39
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 39
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 40
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 40
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 40
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 40
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 40
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 40
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 40
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 40
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 40
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 40
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 40
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 40
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 40
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 40
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 41
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 41
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 41
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 41
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 41
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 41
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 41
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 41
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 41
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 41
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 41
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 41
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 41
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 41
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 41
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 42
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 42
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 42
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 42
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 42
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 42
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 42
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 42
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 42
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 42
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 42
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 42
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 42
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 42
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 43
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 43
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 43
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 43
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 43
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 43
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 43
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 43
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 43
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 43
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 43
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 43
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 43
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 44
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 44
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 44
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 44
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 44
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 44
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 44
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 44
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 44
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 44
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 44
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 44
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 45
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 45
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 45
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 45
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 45
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 45
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 45
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 45
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 45
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 45
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 45
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 46
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 46
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 46
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 46
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 46
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 46
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 46
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 46
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 46
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 46
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 46
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 46
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 46
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 46
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 46
     tile: 29
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 46
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 46
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 46
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 46
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 47
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 47
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 47
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 47
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 47
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 47
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 47
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 47
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 47
     tile: 100
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 47
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 0
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 1
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 8
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 48
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 16
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 21
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 48
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 37
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 38
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 39
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 40
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 41
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 48
     tile: 101
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 49
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 50
     y: 48
     tile: 28
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
 }
 layers {
   id: "layer2"
   z: 0.2
-  is_visible: 1
   cell {
     x: 4
     y: 4
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 4
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 4
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 4
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 5
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 5
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 5
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 5
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 5
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 5
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 5
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 5
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 5
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 5
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 5
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 5
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 6
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 27
     y: 6
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 28
     y: 6
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 29
     y: 6
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 6
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 6
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 6
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 6
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 13
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 13
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 13
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 13
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 13
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 13
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 13
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 13
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 14
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 14
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 14
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 15
     y: 14
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 14
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 14
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 14
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 14
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 19
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 19
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 19
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 19
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 20
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 20
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 20
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 20
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 21
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 21
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 21
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 21
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 22
     y: 22
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 22
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 22
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 22
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 23
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 23
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 23
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 23
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 2
     y: 24
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 3
     y: 24
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 24
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 24
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 26
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 26
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 26
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 26
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 27
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 34
     y: 27
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 35
     y: 27
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 36
     y: 27
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 30
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 30
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 30
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 30
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 30
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 30
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 30
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 30
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 30
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 30
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 30
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 30
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 9
     y: 31
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 10
     y: 31
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 31
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 31
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 23
     y: 31
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 24
     y: 31
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 25
     y: 31
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 26
     y: 31
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 42
     y: 31
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 43
     y: 31
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 44
     y: 31
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 31
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 36
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 36
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 36
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 36
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 11
     y: 37
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 12
     y: 37
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 13
     y: 37
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 14
     y: 37
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 42
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 42
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 42
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 42
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 42
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 42
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 42
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 42
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 4
     y: 43
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 5
     y: 43
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 6
     y: 43
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 7
     y: 43
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 30
     y: 43
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 31
     y: 43
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 32
     y: 43
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 33
     y: 43
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 44
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 44
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 44
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 44
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 44
     tile: 74
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 44
     tile: 75
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 44
     tile: 76
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 44
     tile: 77
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 17
     y: 45
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 18
     y: 45
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 19
     y: 45
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 20
     y: 45
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 45
     y: 45
     tile: 50
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 46
     y: 45
     tile: 51
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 47
     y: 45
     tile: 52
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
   cell {
     x: 48
     y: 45
     tile: 53
-    h_flip: 0
-    v_flip: 0
-    rotate90: 0
   }
 }
 material: "/builtins/materials/tile_map.material"
-blend_mode: BLEND_MODE_ALPHA

--- a/app/main/map.tilesource
+++ b/app/main/map.tilesource
@@ -1,20 +1,9 @@
 image: "/assets/map.png"
 tile_width: 16
 tile_height: 16
-tile_margin: 0
-tile_spacing: 0
-collision: ""
-material_tag: "tile"
 collision_groups: "default"
 animations {
   id: "anim"
   start_tile: 1
   end_tile: 1
-  playback: PLAYBACK_ONCE_FORWARD
-  fps: 30
-  flip_horizontal: 0
-  flip_vertical: 0
 }
-extrude_borders: 0
-inner_padding: 0
-sprite_trim_mode: SPRITE_TRIM_MODE_OFF

--- a/app/main/rocket.go
+++ b/app/main/rocket.go
@@ -1,43 +1,22 @@
 components {
   id: "rocket"
   component: "/scripts/rocket.script"
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
 }
 embedded_components {
   id: "sprite"
   type: "sprite"
-  data: "tile_set: \"/main/sprites.atlas\"\n"
-  "default_animation: \"rocket\"\n"
+  data: "default_animation: \"rocket\"\n"
   "material: \"/builtins/materials/sprite.material\"\n"
-  "blend_mode: BLEND_MODE_ALPHA\n"
+  "textures {\n"
+  "  sampler: \"texture_sampler\"\n"
+  "  texture: \"/main/sprites.atlas\"\n"
+  "}\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
 }
 embedded_components {
   id: "collisionobject"
   type: "collisionobject"
-  data: "collision_shape: \"\"\n"
-  "type: COLLISION_OBJECT_TYPE_KINEMATIC\n"
+  data: "type: COLLISION_OBJECT_TYPE_KINEMATIC\n"
   "mass: 0.0\n"
   "friction: 0.1\n"
   "restitution: 0.5\n"
@@ -48,14 +27,8 @@ embedded_components {
   "    shape_type: TYPE_BOX\n"
   "    position {\n"
   "      x: 3.0\n"
-  "      y: 0.0\n"
-  "      z: 0.0\n"
   "    }\n"
   "    rotation {\n"
-  "      x: 0.0\n"
-  "      y: 0.0\n"
-  "      z: 0.0\n"
-  "      w: 1.0\n"
   "    }\n"
   "    index: 0\n"
   "    count: 3\n"
@@ -64,20 +37,5 @@ embedded_components {
   "  data: 3.715\n"
   "  data: 10.0\n"
   "}\n"
-  "linear_damping: 0.0\n"
-  "angular_damping: 0.0\n"
-  "locked_rotation: false\n"
-  "bullet: false\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
 }

--- a/app/main/sprites.atlas
+++ b/app/main/sprites.atlas
@@ -2,102 +2,74 @@ animations {
   id: "player-down"
   images {
     image: "/assets/units/infantry/down/1.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/units/infantry/down/2.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/units/infantry/down/3.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/units/infantry/down/4.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   playback: PLAYBACK_LOOP_FORWARD
   fps: 8
-  flip_horizontal: 0
-  flip_vertical: 0
 }
 animations {
   id: "rocket"
   images {
     image: "/assets/buildings/turret-rocket/1.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/buildings/turret-rocket/2.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/buildings/turret-rocket/3.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   playback: PLAYBACK_LOOP_FORWARD
   fps: 20
   flip_horizontal: 1
-  flip_vertical: 0
 }
 animations {
   id: "explosion"
   images {
     image: "/assets/fx/explosion/1.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/fx/explosion/2.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/fx/explosion/3.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/fx/explosion/4.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/fx/explosion/5.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/fx/explosion/6.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/fx/explosion/7.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/fx/explosion/8.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/fx/explosion/9.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
-  playback: PLAYBACK_ONCE_FORWARD
   fps: 16
-  flip_horizontal: 0
-  flip_vertical: 0
 }
 animations {
   id: "tank-down"
   images {
     image: "/assets/units/tank/down/1.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   images {
     image: "/assets/units/tank/down/2.png"
-    sprite_trim_mode: SPRITE_TRIM_MODE_OFF
   }
   playback: PLAYBACK_LOOP_FORWARD
   fps: 8
-  flip_horizontal: 0
-  flip_vertical: 0
 }
-margin: 0
 extrude_borders: 2
-inner_padding: 0

--- a/app/main/tank.go
+++ b/app/main/tank.go
@@ -1,28 +1,18 @@
 embedded_components {
   id: "sprite"
   type: "sprite"
-  data: "tile_set: \"/main/sprites.atlas\"\n"
-  "default_animation: \"tank-down\"\n"
+  data: "default_animation: \"tank-down\"\n"
   "material: \"/builtins/materials/sprite.material\"\n"
-  "blend_mode: BLEND_MODE_ALPHA\n"
+  "textures {\n"
+  "  sampler: \"texture_sampler\"\n"
+  "  texture: \"/main/sprites.atlas\"\n"
+  "}\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
 }
 embedded_components {
   id: "collisionobject"
   type: "collisionobject"
-  data: "collision_shape: \"\"\n"
-  "type: COLLISION_OBJECT_TYPE_KINEMATIC\n"
+  data: "type: COLLISION_OBJECT_TYPE_KINEMATIC\n"
   "mass: 0.0\n"
   "friction: 0.1\n"
   "restitution: 0.5\n"
@@ -32,15 +22,8 @@ embedded_components {
   "  shapes {\n"
   "    shape_type: TYPE_BOX\n"
   "    position {\n"
-  "      x: 0.0\n"
-  "      y: 0.0\n"
-  "      z: 0.0\n"
   "    }\n"
   "    rotation {\n"
-  "      x: 0.0\n"
-  "      y: 0.0\n"
-  "      z: 0.0\n"
-  "      w: 1.0\n"
   "    }\n"
   "    index: 0\n"
   "    count: 3\n"
@@ -49,20 +32,5 @@ embedded_components {
   "  data: 12.627\n"
   "  data: 10.0\n"
   "}\n"
-  "linear_damping: 0.0\n"
-  "angular_damping: 0.0\n"
-  "locked_rotation: false\n"
-  "bullet: false\n"
   ""
-  position {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
 }

--- a/app/main/text.font
+++ b/app/main/text.font
@@ -1,17 +1,4 @@
 font: "/assets/fonts/04font.ttf"
 material: "/builtins/fonts/font.material"
 size: 15
-antialias: 1
-alpha: 1.0
-outline_alpha: 0.0
-outline_width: 0.0
-shadow_alpha: 0.0
-shadow_blur: 0
-shadow_x: 0.0
-shadow_y: 0.0
-extra_characters: ""
-output_format: TYPE_BITMAP
-all_chars: false
-cache_width: 0
-cache_height: 0
-render_mode: MODE_SINGLE_LAYER
+characters: " !\"#$%&\'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"

--- a/app/main/ui.gui
+++ b/app/main/ui.gui
@@ -3,74 +3,31 @@ fonts {
   name: "text"
   font: "/main/text.font"
 }
-background_color {
-  x: 0.0
-  y: 0.0
-  z: 0.0
-  w: 0.0
-}
 nodes {
   position {
     x: 12.0
     y: 699.0
-    z: 0.0
-    w: 1.0
-  }
-  rotation {
-    x: 0.0
-    y: 0.0
-    z: 0.0
-    w: 1.0
-  }
-  scale {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   size {
     x: 200.0
     y: 100.0
-    z: 0.0
-    w: 1.0
-  }
-  color {
-    x: 1.0
-    y: 1.0
-    z: 1.0
-    w: 1.0
   }
   type: TYPE_TEXT
-  blend_mode: BLEND_MODE_ALPHA
   text: "SCORE: 0"
   font: "text"
   id: "score"
-  xanchor: XANCHOR_NONE
-  yanchor: YANCHOR_NONE
   pivot: PIVOT_W
   outline {
     x: 1.0
     y: 1.0
     z: 1.0
-    w: 1.0
   }
   shadow {
     x: 1.0
     y: 1.0
     z: 1.0
-    w: 1.0
   }
-  adjust_mode: ADJUST_MODE_FIT
-  line_break: false
-  layer: ""
   inherit_alpha: true
-  alpha: 1.0
-  outline_alpha: 1.0
-  shadow_alpha: 1.0
-  template_node_child: false
-  text_leading: 1.0
-  text_tracking: 0.0
 }
 material: "/builtins/materials/gui.material"
 adjust_reference: ADJUST_REFERENCE_PARENT
-max_nodes: 512


### PR DESCRIPTION
As of [v1.9.1](https://forum.defold.com/t/defold-1-9-1-has-been-released/77534), Defold uses sparse file formats (values matching defaults are not saved.)

This PR upgrades to the newer format. No change in functionality is expected.